### PR TITLE
fix(docs): Add userID groupID parameters to docker call

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install development container configuration files to your repository for one of 
 ### Docker
 
 ```sh
-docker run -it --rm -v "/yourrepopath:/repository" qmcgaw/devtainr -dev go -path /repository -name projectname
+docker run -it --rm --user="$(id -u):$(id -g)" -v "/yourrepopath:/repository" qmcgaw/devtainr -dev go -path /repository -name projectname
 📁 Creating .devcontainer directory...✔️
 📥 Downloading .dockerignore...✔️
 📥 Downloading Dockerfile...✔️


### PR DESCRIPTION
Without this parameter, the directory `.devcontianer` (and all files created in it) will belong to root. Thus changes to those files from within your IDE will be difficult.

Closes #3 
Closes qdm12/rustdevcontainer#4

